### PR TITLE
Improve Codex Cloud bootstrap validation

### DIFF
--- a/docs/codex-cloud/environment_setup_tasks.md
+++ b/docs/codex-cloud/environment_setup_tasks.md
@@ -1,56 +1,143 @@
-# Codex Cloud Environment Setup Tasks
+# Codex Cloud Environment Setup Playbook
 
-This document outlines the tasks required to prepare an OpenAI Codex Cloud environment so the Codex agent can work effectively on the **ComfyUI LoRA Manager** repository.
+The instructions below expand the high-level task list into the precise steps required to bring the **ComfyUI LoRA Manager** repository online inside an OpenAI Codex Cloud workspace.
 
-## 1. Establish the Baseline Environment
-- **Container image**: Use the default `codex-universal` image so the agent has Python, Node, Git, and common build tools pre-installed.
-- **Runtime versions**: Pin Python to 3.10 or 3.11 (both are supported by `codex-universal`) to match the repository's tooling expectations.
-- **Network access**: Enable internet access during setup to install Python dependencies. Runtime network access can remain disabled unless tasks require calling external APIs.
+---
 
-## 2. Fetch Repository Source
-- Configure the environment to clone `willmiao/ComfyUI-Lora-Manager` at the desired branch or commit.
-- Ensure submodules (none in this repo) are handled if added in the future.
+## 0. Launch the Workspace
 
-## 3. Prepare Configuration Files
-- Copy `settings.json.example` to `settings.json` when workflows need to read configuration. Update folder paths or API keys only if a task depends on real data; otherwise keep placeholder values to avoid exposing secrets.
-- Persist any environment variables by appending them to `~/.bashrc` if the agent will need them across sessions (e.g., `CIVITAI_API_KEY`).
+1. Create a new Codex Cloud workspace (or reset an existing one) using the `codex-universal` image.
+2. Select Python **3.10** or **3.11** in the runtime dropdown. (All scripts below default to `python3`, which resolves to one of these versions inside `codex-universal`.)
+3. Enable outbound network access during initialization so that pip can download dependencies.
+4. (Optional) Add a startup command that runs the setup script described below if you want the workspace to self-bootstrap on every reset.
 
-## 4. Implement the Setup Script
-Create a setup script executed before the agent session:
+---
+
+## 1. Clone the Repository
+
+From the workspace terminal:
 
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Ensure modern packaging tools
-python -m pip install --upgrade pip setuptools wheel
-
-# Install runtime dependencies
-python -m pip install -r requirements.txt
-
-# Install extra developer utilities
-python -m pip install pytest
+cd /workspace
+rm -rf ComfyUI-Lora-Manager  # start clean when resetting the workspace
+git clone https://github.com/willmiao/ComfyUI-Lora-Manager.git
+cd ComfyUI-Lora-Manager
 ```
 
-- Add additional packages (e.g., `ruff`, `black`, or `pyright`) if linting/static analysis will be delegated to Codex.
-- If the agent needs editable installs, append `python -m pip install -e .`.
+If you need to pin a specific branch or commit, add `--branch <name>` or `git checkout <commit>` after cloning.
 
-## 5. Define Maintenance Commands
-- Provide a maintenance script or AGENTS.md instructions so the agent routinely runs:
-  - `pytest` (or `python -m pytest test_i18n.py`) to validate locale consistency.
-  - `python standalone.py --help` or a smoke test command if the standalone server must start.
-- Document how to start the web UI locally: `python standalone.py --host 0.0.0.0 --port 8188`.
+---
 
-## 6. Validate the Environment
-- After setup, execute the test suite to confirm dependencies installed correctly: `pytest`.
-- Optionally run `python test_i18n.py` for a more verbose locale report when debugging translations.
-- Verify static assets load by ensuring the `static/` and `templates/` directories are present (no build step required).
+## 2. Run the Automated Bootstrap Script
 
-## 7. Optional Enhancements
-- Install formatting/linting tools used by contributors (e.g., `ruff`, `black`) to keep code style consistent.
-- Add a smoke-test script that starts `standalone.py` in the background and hits `http://localhost:8188/loras` using `curl` to ensure the server boots.
-- Configure caching (e.g., pip cache) if repeated runs require faster dependency installs.
+The repository now includes `scripts/codex_cloud_setup.sh`, which encapsulates all required environment preparation steps (pip tooling upgrades, dependency installation, developer utilities, and the default configuration file).
 
-## 8. Document Environment Expectations
-- Record all commands and environment specifics in repository docs (e.g., AGENTS.md) so future Codex tasks follow the same workflow.
-- Note any long-running commands or services the agent should avoid unless explicitly required.
+```bash
+./scripts/codex_cloud_setup.sh
+```
+
+### What the script does
+- Upgrades `pip`, `setuptools`, and `wheel` for reliable installs.
+- Installs the application dependencies from `requirements.txt`.
+- Installs the developer tooling Codex frequently uses (`pytest`, `black`, and `ruff`).
+- Copies `settings.json.example` to `settings.json` if the latter does not exist yet.
+
+### Customizing the Python interpreter
+If the workspace exposes multiple Python interpreters, run the script with:
+
+```bash
+PYTHON_BIN=python3.10 ./scripts/codex_cloud_setup.sh
+```
+
+### Skipping developer tooling (optional)
+If you want to leave out `pytest`, `black`, and `ruff`, disable that portion of the script with:
+
+```bash
+INSTALL_DEV_TOOLS=0 ./scripts/codex_cloud_setup.sh
+```
+
+The environment summary printed at the end confirms which interpreter was used, whether developer tooling was installed, and whether `settings.json` is in place.
+
+---
+
+## 3. Review and Edit `settings.json`
+
+`settings.json` controls filesystem paths and optional API keys. After running the setup script:
+
+1. Open the file: `code settings.json` (or use the Codex Cloud editor).
+2. Update the placeholder model directories if the workspace has mounted model storage.
+3. If you plan to exercise the CivitAI integration, add the API key you want the agent to use. Avoid hard-coding secrets into commits; instead, export them as environment variables (see below).
+
+To persist sensitive values across terminals, append them to `~/.bashrc` and reload the shell:
+
+```bash
+echo 'export CIVITAI_API_KEY="<your key>"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+---
+
+## 4. (Optional) Prime Caches for Faster Iteration
+
+Codex Cloud workspaces are ephemeral, so caching pip downloads can save time:
+
+```bash
+mkdir -p ~/.cache/pip
+```
+
+`pip` will automatically reuse this directory on subsequent runs of the setup script.
+
+---
+
+## 5. Verify the Installation
+
+Run the bundled verification script to ensure the agent can execute the project’s regression checks:
+
+```bash
+./scripts/codex_cloud_run_checks.sh
+```
+
+This script performs two actions:
+
+1. Executes `python test_i18n.py`, which validates locale files and prints a summary of unused keys. Using the direct Python invocation avoids `pytest`'s package discovery issues with the repository’s flat layout.
+2. Captures `python standalone.py --help` output (stored at `/tmp/codex_cloud_standalone_help.txt`) to confirm the standalone server starts without raising import errors. Expect warnings about missing model directories when running in a pristine workspace.
+
+If either step fails, re-run the setup script and address the reported error before continuing.
+
+---
+
+## 6. Launch the Standalone Server (When Needed)
+
+To run the application locally inside the workspace:
+
+```bash
+python standalone.py --host 0.0.0.0 --port 8188
+```
+
+Forward port **8188** in Codex Cloud and visit `http://localhost:8188/loras` from your browser. Stop the server with `Ctrl+C` when done.
+
+---
+
+## 7. Day-to-Day Maintenance
+
+- Re-run `./scripts/codex_cloud_setup.sh` whenever `requirements.txt` changes.
+- Execute `./scripts/codex_cloud_run_checks.sh` before handing the workspace to Codex to ensure locale tests still pass and the server imports cleanly.
+- Use `black`/`ruff` (installed by the setup script) for formatting and linting when the task requires it:
+  ```bash
+  ruff check .
+  black .
+  ```
+- Keep environment variables in `~/.bashrc` so the agent inherits them on new shells.
+
+---
+
+## 8. Troubleshooting Tips
+
+| Symptom | Resolution |
+| --- | --- |
+| `pytest` fails with `ImportError while importing test module '/workspace/ComfyUI-Lora-Manager/__init__.py'` | Prefer `python test_i18n.py` (already handled by `codex_cloud_run_checks.sh`). The repository’s layout confuses pytest’s package discovery when invoked directly. |
+| `ModuleNotFoundError` for dependencies | Re-run `./scripts/codex_cloud_setup.sh` or check that `PYTHON_BIN` points to Python 3.10/3.11. |
+| Warnings about missing LoRA/checkpoint folders when running `standalone.py` | Populate the relevant paths in `settings.json` if your workflow needs real model directories; otherwise these warnings are expected in a clean workspace. |
+| Need to test against a different branch | `git fetch origin && git checkout <branch>` followed by `./scripts/codex_cloud_setup.sh` ensures dependencies align with the new checkout. |
+
+With these steps the Codex agent inherits a fully prepared development environment and a repeatable checklist for validation.

--- a/scripts/codex_cloud_run_checks.sh
+++ b/scripts/codex_cloud_run_checks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+"${PYTHON_BIN}" test_i18n.py
+"${PYTHON_BIN}" standalone.py --help >/tmp/codex_cloud_standalone_help.txt
+
+echo "Codex Cloud verification complete."
+echo "- test_i18n.py -> passed"
+echo "- standalone.py --help output recorded at /tmp/codex_cloud_standalone_help.txt"

--- a/scripts/codex_cloud_setup.sh
+++ b/scripts/codex_cloud_setup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allow callers to override the Python interpreter, defaulting to python3
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+INSTALL_DEV_TOOLS="${INSTALL_DEV_TOOLS:-1}"
+
+log() {
+    printf '[codex-setup] %s\n' "$1"
+}
+
+die() {
+    printf 'Error: %s\n' "$1" >&2
+    exit 1
+}
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    die "Python interpreter '$PYTHON_BIN' is not available. Set PYTHON_BIN to a valid interpreter (e.g. python3.11)."
+fi
+
+PYTHON_VERSION="$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+PYTHON_MAJOR_MINOR="$($PYTHON_BIN -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')"
+case "$PYTHON_MAJOR_MINOR" in
+    3.10|3.11) ;;
+    *)
+        die "Python $PYTHON_VERSION detected. Codex Cloud setup expects Python 3.10 or 3.11. Set PYTHON_BIN accordingly."
+        ;;
+esac
+
+# Resolve repository root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+PIP_CMD=("${PYTHON_BIN}" -m pip)
+
+log "Upgrading pip tooling"
+"${PIP_CMD[@]}" install --upgrade pip setuptools wheel
+
+if [[ -f requirements.txt ]]; then
+    log "Installing application dependencies from requirements.txt"
+    "${PIP_CMD[@]}" install --upgrade --requirement requirements.txt
+else
+    log "requirements.txt not found; skipping runtime dependency installation"
+fi
+
+if [[ "${INSTALL_DEV_TOOLS}" != "0" ]]; then
+    log "Installing developer utilities (pytest, black, ruff)"
+    "${PIP_CMD[@]}" install --upgrade pytest black ruff
+else
+    log "Skipping developer utility installation (INSTALL_DEV_TOOLS=${INSTALL_DEV_TOOLS})"
+fi
+
+if [[ ! -f settings.json && -f settings.json.example ]]; then
+    log "Provisioning default settings.json from template"
+    cp settings.json.example settings.json
+fi
+
+SETTINGS_STATUS="missing"
+if [[ -f settings.json ]]; then
+    SETTINGS_STATUS="present"
+fi
+
+cat <<SCRIPT_SUMMARY
+Codex Cloud environment bootstrap complete.
+- Python interpreter: ${PYTHON_BIN} (${PYTHON_VERSION})
+- Dependencies installed from requirements.txt: $(if [[ -f requirements.txt ]]; then echo "yes"; else echo "no"; fi)
+- Developer tools installed: $(if [[ "${INSTALL_DEV_TOOLS}" != "0" ]]; then echo "yes"; else echo "no"; fi)
+- settings.json status: ${SETTINGS_STATUS}
+SCRIPT_SUMMARY


### PR DESCRIPTION
## Summary
- harden the Codex Cloud setup script with Python interpreter validation, logging helpers, conditional developer tooling installation, and enhanced status reporting
- document the optional INSTALL_DEV_TOOLS flag alongside the existing PYTHON_BIN override in the Codex Cloud environment playbook

## Testing
- ./scripts/codex_cloud_setup.sh
- ./scripts/codex_cloud_run_checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68cb31562f84832887e07798c2466f81