### PR TITLE
Clarify fork scope and disable upstream publishing metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+> [!NOTE]
+> This template is for the **DeadBranches UI/UX fork** of ComfyUI LoRA Manager. Confirm the problem occurs on this fork and reference issues using the fully qualified form (`DeadBranches/ComfyUI-Lora-Manager#…`) to avoid confusion with the upstream project.
+
 ### **LoRA Manager Version**
 - Version: `vX.X.X`
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+> [!NOTE]
+> This template is for the **DeadBranches UI/UX fork** of ComfyUI LoRA Manager. Confirm your request targets this fork and cite related discussions using `DeadBranches/ComfyUI-Lora-Manager#…` so conversations stay anchored here.
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# NOTE: This workflow is intentionally disabled for the DeadBranches fork.
+# It remains in the repository as historical reference only.
 name: Publish to Comfy registry
 on:
   workflow_dispatch:
@@ -15,7 +17,7 @@ jobs:
   publish-node:
     name: Publish Custom Node to registry
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'willmiao' }}
+    if: ${{ false }} # Disabled: this fork does not publish to the Comfy registry
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 
 > **Revolutionize your workflow with the ultimate LoRA companion for ComfyUI!**
 
+> [!IMPORTANT]
+> This repository (`DeadBranches/ComfyUI-Lora-Manager`) is a personal fork that tracks UI/UX experiments and quality-of-life work separate from the upstream project maintained by [@willmiao](https://github.com/willmiao/ComfyUI-Lora-Manager). Issues, pull requests, and release planning happen **only** in this fork’s tracker. When cross-referencing GitHub issues, always include the owner (for example, `DeadBranches/ComfyUI-Lora-Manager#1`) so links point to the correct repository. The upstream badges and registry publishing workflow remain disabled here because this fork is not distributed through the Comfy Registry. See [docs/fork-notes.md](./docs/fork-notes.md) for the full context and maintenance guidelines.
+
 [![Discord](https://img.shields.io/discord/1346296675538571315?color=7289DA&label=Discord&logo=discord&logoColor=white)](https://discord.gg/vcqNrWVFvM)
-[![Release](https://img.shields.io/github/v/release/willmiao/ComfyUI-Lora-Manager?include_prereleases&color=blue&logo=github)](https://github.com/willmiao/ComfyUI-Lora-Manager/releases)
-[![Release Date](https://img.shields.io/github/release-date/willmiao/ComfyUI-Lora-Manager?color=green&logo=github)](https://github.com/willmiao/ComfyUI-Lora-Manager/releases)
+
+> Looking for the upstream project? Visit [willmiao/ComfyUI-Lora-Manager](https://github.com/willmiao/ComfyUI-Lora-Manager).
 
 A comprehensive toolset that streamlines organizing, downloading, and applying LoRA models in ComfyUI. With powerful features like recipe management, checkpoint organization, and one-click workflow integration, working with models becomes faster, smoother, and significantly easier. Access the interface at: `http://localhost:8188/loras`
 
-![Interface Preview](https://github.com/willmiao/ComfyUI-Lora-Manager/blob/main/static/images/screenshot.png)
+![Interface Preview](./static/images/screenshot.png)
 
 ## 📺 Tutorial: One-Click LoRA Integration
 Watch this quick tutorial to learn how to use the new one-click LoRA integration feature:
 
-[![One-Click LoRA Integration Tutorial](https://github.com/willmiao/ComfyUI-Lora-Manager/blob/main/static/images/video-thumbnails/getting-started.jpg)](https://youtu.be/hvKw31YpE-U)
+[![One-Click LoRA Integration Tutorial](./static/images/video-thumbnails/getting-started.jpg)](https://youtu.be/hvKw31YpE-U)
 
 ## 🌐 Browser Extension
 Enhance your Civitai browsing experience with our companion browser extension! See which models you already have, download new ones with a single click, and manage your downloads efficiently.
 
-![LM Civitai Extension Preview](https://github.com/willmiao/ComfyUI-Lora-Manager/blob/main/wiki-images/civitai-models-page.png)
+![LM Civitai Extension Preview](./wiki-images/civitai-models-page.png)
 
 <div>
   <a href="https://chromewebstore.google.com/detail/lm-civitai-extension/capigligggeijgmocnaflanlbghnamgm?utm_source=item-share-cb" style="display: inline-block; background-color: #4285F4; color: white; padding: 8px 16px; text-decoration: none; border-radius: 4px; font-weight: bold; margin: 10px 0;">
@@ -130,6 +133,9 @@ Enhance your Civitai browsing experience with our companion browser extension! S
 
 ## Installation
 
+> [!NOTE]
+> Options 1 and 2 reference upstream distribution channels that currently ship the original release. To work with the DeadBranches fork source code directly, use **Option 3**.
+
 ### Option 1: **ComfyUI Manager** (Recommended for ComfyUI users)
 
 1. Open **ComfyUI**.
@@ -139,7 +145,7 @@ Enhance your Civitai browsing experience with our companion browser extension! S
 
 ### Option 2: **Portable Standalone Edition** (No ComfyUI required)
 
-1. Download the [Portable Package](https://github.com/willmiao/ComfyUI-Lora-Manager/releases/download/v0.9.2/lora_manager_portable.7z)
+1. Download the upstream [Portable Package](https://github.com/willmiao/ComfyUI-Lora-Manager/releases/download/v0.9.2/lora_manager_portable.7z)
 2. Copy the provided `settings.json.example` file to create a new file named `settings.json` in `comfyui-lora-manager` folder
 3. Edit `settings.json` to include your correct model folder paths and CivitAI API key
 4. Run run.bat
@@ -148,7 +154,7 @@ Enhance your Civitai browsing experience with our companion browser extension! S
 ### Option 3: **Manual Installation**
 
 ```bash
-git clone https://github.com/willmiao/ComfyUI-Lora-Manager.git
+git clone https://github.com/DeadBranches/ComfyUI-Lora-Manager.git
 cd ComfyUI-Lora-Manager
 pip install -r requirements.txt
 ```

--- a/docs/fork-notes.md
+++ b/docs/fork-notes.md
@@ -1,0 +1,21 @@
+# DeadBranches Fork Notes
+
+This document captures the divergence between the DeadBranches fork of **ComfyUI LoRA Manager** and the upstream repository maintained by [@willmiao](https://github.com/willmiao/ComfyUI-Lora-Manager). It exists to prevent future confusion when discussing issues, workflows, or release processes.
+
+## Why this fork exists
+- Track and prototype UI/UX improvements that may not be suitable for the upstream project.
+- Experiment with alternative workflows without affecting users of the upstream release.
+- Provide a staging ground for DeadBranches-specific features before they are stabilized.
+
+## Common sources of confusion
+1. **Issue and pull request links** – GitHub issue numbers restart per repository. Always prefix references with the owner/repo (for example, `DeadBranches/ComfyUI-Lora-Manager#12`) so discussions stay anchored to this fork.
+2. **Registry publishing workflow** – The upstream project publishes to the Comfy Registry, but this fork does not. The workflow file is retained for reference yet intentionally disabled. Treat it as documentation rather than an active pipeline.
+3. **Project metadata** – The upstream `pyproject.toml` advertised registry metadata. In this fork the metadata only records dependencies; registry-specific fields have been removed to avoid implying the fork is published.
+4. **Documentation links** – Historical Markdown content linked directly to the upstream repository for screenshots and downloads. Using relative paths keeps documentation self-contained and avoids implying assets live in the upstream project.
+
+## Maintenance guidelines
+- When creating or triaging issues, link to commits in this repository and mention the fork explicitly in summaries if there is any overlap with upstream work.
+- Keep documentation changes synchronized with this fork’s UI/UX direction. Reference upstream docs only when explicitly comparing behaviour.
+- If registry publishing ever becomes relevant, document the required changes in this file before re-enabling the workflow so the intent remains clear.
+
+For contributors who need the production-ready version, direct them to the upstream project at [willmiao/ComfyUI-Lora-Manager](https://github.com/willmiao/ComfyUI-Lora-Manager).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,8 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/willmiao/ComfyUI-Lora-Manager"
-#  Used by Comfy Registry https://comfyregistry.org
+Repository = "https://github.com/DeadBranches/ComfyUI-Lora-Manager"
 
-[tool.comfy]
-PublisherId = "willmiao"
-DisplayName = "ComfyUI-Lora-Manager"
-Icon = "https://github.com/willmiao/ComfyUI-Lora-Manager/blob/main/static/images/android-chrome-512x512.png?raw=true"
+# The upstream project advertised Comfy Registry metadata here. This fork does not
+# publish to the registry, so the section has been removed intentionally to avoid
+# suggesting that registry automation is supported.


### PR DESCRIPTION
## Summary
- document the DeadBranches fork scope in the README, add fork notes, and update install guidance to avoid upstream confusion
- remind contributors in issue templates to reference this repository explicitly when filing reports or requests
- disable the registry publishing workflow and remove upstream registry metadata from the project manifest

## Testing
- ./scripts/codex_cloud_run_checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68cb4401d73c8328b0c8c78b278eee8a